### PR TITLE
Added a script to automatically compile all the cuda functions.

### DIFF
--- a/compile_cuda_func.py
+++ b/compile_cuda_func.py
@@ -1,0 +1,24 @@
+import argparse
+import subprocess
+from pathlib import Path
+
+# GPU Architecture Code for Titan RTX
+ARCH = 'sm_75'
+
+def main():
+    parser = argparse.ArgumentParser(description='Compile CUDA functions for the current machine\'s GPU')
+    parser.add_argument('-a', '--arch', action='store',
+            required=True, help='The architecture code of this machine\'s GPU')
+    args = parser.parse_args()
+    path = Path('./cuda_functions')
+    for nms in path.glob('nms_*D'):
+        subprocess.run('nvcc -c -o nms_kernel.cu.o nms_kernel.cu -x cu -Xcompiler -fPIC -arch={}'.format(args.arch),
+                cwd=nms/'src/cuda', shell=True)
+        subprocess.run('python build.py', cwd=nms, shell=True)
+    for roi in path.glob('roi_align_.*D'):
+        subprocess.run(('nvcc -c -o crop_and_resize_kernel.cu.o crop_and_resize_kernel.cu -x cu -Xcompiler -fPIC -arch={}').format(args.arch),
+                cwd=roi/'src/cuda', shell=True)
+        subprocess.run('python build.py', cwd=roi, shell=True)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Here is how it works.

```
>  python compile_cuda_func.py -h
usage: compile_cuda_func.py [-h] -a ARCH

Compile CUDA functions for the current machine's GPU

optional arguments:
  -h, --help            show this help message and exit
  -a ARCH, --arch ARCH  The architecture code of this machine's GPU
```

It is a simple command-line Python script that automatically compiles all the CUDA functions given an arch code.

```
>  python compile_cuda_func.py --arch sm_75

Including CUDA code.
/home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_2D
generating /tmp/tmppevdo6dr/_nms.c
setting the current directory to '/tmp/tmppevdo6dr'
running build_ext
building '_nms' extension
creating home
creating home/odysseus
creating home/odysseus/medicaldetectiontoolkit
creating home/odysseus/medicaldetectiontoolkit/cuda_functions
creating home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_2D
creating home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_2D/src
gcc -pthread -B /home/odysseus/miniconda3/envs/mdt/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DWITH_CUDA -I/home/odysseus/miniconda3/envs/mdt/lib/python3.7/site-packages/torch/utils/ffi/../../lib/include -I/home/odysseus/miniconda3/envs/mdt/lib/python3.7/site-packages/torch/utils/ffi/../../lib/include/TH -I/home/odysseus/miniconda3/envs/mdt/lib/python3.7/site-packages/torch/utils/ffi/../../lib/include/THC -I/usr/local/cuda/include -I/home/odysseus/miniconda3/envs/mdt/include/python3.7m -c _nms.c -o ./_nms.o -std=c99
gcc -pthread -B /home/odysseus/miniconda3/envs/mdt/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DWITH_CUDA -I/home/odysseus/miniconda3/envs/mdt/lib/python3.7/site-packages/torch/utils/ffi/../../lib/include -I/home/odysseus/miniconda3/envs/mdt/lib/python3.7/site-packages/torch/utils/ffi/../../lib/include/TH -I/home/odysseus/miniconda3/envs/mdt/lib/python3.7/site-packages/torch/utils/ffi/../../lib/include/THC -I/usr/local/cuda/include -I/home/odysseus/miniconda3/envs/mdt/include/python3.7m -c /home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_2D/src/nms.c -o ./home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_2D/src/nms.o -std=c99
gcc -pthread -B /home/odysseus/miniconda3/envs/mdt/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DWITH_CUDA -I/home/odysseus/miniconda3/envs/mdt/lib/python3.7/site-packages/torch/utils/ffi/../../lib/include -I/home/odysseus/miniconda3/envs/mdt/lib/python3.7/site-packages/torch/utils/ffi/../../lib/include/TH -I/home/odysseus/miniconda3/envs/mdt/lib/python3.7/site-packages/torch/utils/ffi/../../lib/include/THC -I/usr/local/cuda/include -I/home/odysseus/miniconda3/envs/mdt/include/python3.7m -c /home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_2D/src/nms_cuda.c -o ./home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_2D/src/nms_cuda.o -std=c99
/home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_2D/src/nms_cuda.c: In function ‘gpu_nms’:
/home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_2D/src/nms_cuda.c:29:35: warning: initialization from incompatible pointer type [-Wincompatible-pointer-types]
   unsigned long long* mask_flat = THCudaLongTensor_data(state, mask);
                                   ^~~~~~~~~~~~~~~~~~~~~
/home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_2D/src/nms_cuda.c:37:40: warning: initialization from incompatible pointer type [-Wincompatible-pointer-types]
   unsigned long long * mask_cpu_flat = THLongTensor_data(mask_cpu);
                                        ^~~~~~~~~~~~~~~~~
/home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_2D/src/nms_cuda.c:40:39: warning: initialization from incompatible pointer type [-Wincompatible-pointer-types]
   unsigned long long* remv_cpu_flat = THLongTensor_data(remv_cpu);
                                       ^~~~~~~~~~~~~~~~~
/home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_2D/src/nms_cuda.c:23:7: warning: unused variable ‘boxes_dim’ [-Wunused-variable]
   int boxes_dim = THCudaTensor_size(state, boxes, 1);
       ^~~~~~~~~
gcc -pthread -shared -B /home/odysseus/miniconda3/envs/mdt/compiler_compat -L/home/odysseus/miniconda3/envs/mdt/lib -Wl,-rpath=/home/odysseus/miniconda3/envs/mdt/lib -Wl,--no-as-needed -Wl,--sysroot=/ ./_nms.o ./home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_2D/src/nms.o ./home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_2D/src/nms_cuda.o /home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_2D/src/cuda/nms_kernel.cu.o -o ./_nms.so
Including CUDA code.
/home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_3D
generating /tmp/tmpb30tanu9/_nms.c
setting the current directory to '/tmp/tmpb30tanu9'
running build_ext
building '_nms' extension
creating home
creating home/odysseus
creating home/odysseus/medicaldetectiontoolkit
creating home/odysseus/medicaldetectiontoolkit/cuda_functions
creating home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_3D
creating home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_3D/src
gcc -pthread -B /home/odysseus/miniconda3/envs/mdt/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DWITH_CUDA -I/home/odysseus/miniconda3/envs/mdt/lib/python3.7/site-packages/torch/utils/ffi/../../lib/include -I/home/odysseus/miniconda3/envs/mdt/lib/python3.7/site-packages/torch/utils/ffi/../../lib/include/TH -I/home/odysseus/miniconda3/envs/mdt/lib/python3.7/site-packages/torch/utils/ffi/../../lib/include/THC -I/usr/local/cuda/include -I/home/odysseus/miniconda3/envs/mdt/include/python3.7m -c _nms.c -o ./_nms.o -std=c99
gcc -pthread -B /home/odysseus/miniconda3/envs/mdt/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DWITH_CUDA -I/home/odysseus/miniconda3/envs/mdt/lib/python3.7/site-packages/torch/utils/ffi/../../lib/include -I/home/odysseus/miniconda3/envs/mdt/lib/python3.7/site-packages/torch/utils/ffi/../../lib/include/TH -I/home/odysseus/miniconda3/envs/mdt/lib/python3.7/site-packages/torch/utils/ffi/../../lib/include/THC -I/usr/local/cuda/include -I/home/odysseus/miniconda3/envs/mdt/include/python3.7m -c /home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_3D/src/nms.c -o ./home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_3D/src/nms.o -std=c99
gcc -pthread -B /home/odysseus/miniconda3/envs/mdt/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DWITH_CUDA -I/home/odysseus/miniconda3/envs/mdt/lib/python3.7/site-packages/torch/utils/ffi/../../lib/include -I/home/odysseus/miniconda3/envs/mdt/lib/python3.7/site-packages/torch/utils/ffi/../../lib/include/TH -I/home/odysseus/miniconda3/envs/mdt/lib/python3.7/site-packages/torch/utils/ffi/../../lib/include/THC -I/usr/local/cuda/include -I/home/odysseus/miniconda3/envs/mdt/include/python3.7m -c /home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_3D/src/nms_cuda.c -o ./home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_3D/src/nms_cuda.o -std=c99
/home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_3D/src/nms_cuda.c: In function ‘gpu_nms’:
/home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_3D/src/nms_cuda.c:29:35: warning: initialization from incompatible pointer type [-Wincompatible-pointer-types]
   unsigned long long* mask_flat = THCudaLongTensor_data(state, mask);
                                   ^~~~~~~~~~~~~~~~~~~~~
/home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_3D/src/nms_cuda.c:37:40: warning: initialization from incompatible pointer type [-Wincompatible-pointer-types]
   unsigned long long * mask_cpu_flat = THLongTensor_data(mask_cpu);
                                        ^~~~~~~~~~~~~~~~~
/home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_3D/src/nms_cuda.c:40:39: warning: initialization from incompatible pointer type [-Wincompatible-pointer-types]
   unsigned long long* remv_cpu_flat = THLongTensor_data(remv_cpu);
                                       ^~~~~~~~~~~~~~~~~
/home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_3D/src/nms_cuda.c:23:7: warning: unused variable ‘boxes_dim’ [-Wunused-variable]
   int boxes_dim = THCudaTensor_size(state, boxes, 1);
       ^~~~~~~~~
gcc -pthread -shared -B /home/odysseus/miniconda3/envs/mdt/compiler_compat -L/home/odysseus/miniconda3/envs/mdt/lib -Wl,-rpath=/home/odysseus/miniconda3/envs/mdt/lib -Wl,--no-as-needed -Wl,--sysroot=/ ./_nms.o ./home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_3D/src/nms.o ./home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_3D/src/nms_cuda.o /home/odysseus/medicaldetectiontoolkit/cuda_functions/nms_3D/src/cuda/nms_kernel.cu.o -o ./_nms.so
```