### PR TITLE
fix indexerror for retinanet in torch1.x

### DIFF
--- a/models/retina_net.py
+++ b/models/retina_net.py
@@ -209,7 +209,7 @@ def refine_detections(anchors, probs, deltas, batch_ixs, cf):
     flat_probs, flat_probs_order = fg_probs.view(-1).sort(descending=True)
     keep_ix = flat_probs_order[:cf.pre_nms_limit]
     # reshape indices to 2D index array with shape like fg_probs.
-    keep_arr = torch.cat(((keep_ix / fg_probs.shape[1]).unsqueeze(1), (keep_ix % fg_probs.shape[1]).unsqueeze(1)), 1)
+    keep_arr = torch.cat(((keep_ix // fg_probs.shape[1]).unsqueeze(1), (keep_ix % fg_probs.shape[1]).unsqueeze(1)), 1)
 
     pre_nms_scores = flat_probs[:cf.pre_nms_limit]
     pre_nms_class_ids = keep_arr[:, 1] + 1  # add background again.


### PR DESCRIPTION
`keep_ix / fg_probs.shape[1]` returns a float tensor  which can not be used as index with torch 1.x.